### PR TITLE
фикс фикса проверки, установлен ли модуль app_gpstrack

### DIFF
--- a/modules/idevices/idevices.class.php
+++ b/modules/idevices/idevices.class.php
@@ -421,7 +421,7 @@ class idevices extends module {
       $prop['POSITION_TYPE'] = $this->FindMyiPhone->devices[$device['DEVICE_ID']]->API['location']['positionType'];
       $prop['UPDATED'] = date('Y-m-d H:i:s', substr($location->timestamp, 0, -3));
       SQLUpdateInsert('idevices', $prop);
-      if(file_exists(DIR_MODULES.'app_gpstrack/installed') || count(SQLSelectOne("select ID from plugins where module_name='app_gpstrack'"))) {
+      if(file_exists(DIR_MODULES.'app_gpstrack/installed') || count(SQLSelectOne("select ID from plugins where module_name='app_gpstrack'") ?? [])) {
         $url = BASE_URL . '/gps.php?latitude=' . str_replace(',', '.', $prop['LATITUDE'])
         . '&longitude=' . str_replace(',', '.', $prop['LONGITUDE'])
         . '&altitude=' . 0


### PR DESCRIPTION
Функция SQLSelectOne() возвращает null если не удалось получить результат выборки, функция count() начиная с версии 7.2(если не ошибаюсь) тригерит ошибку если на нее передали не array или  object реализующий интерфейс Countable. Из-за этого проверка просто падает.